### PR TITLE
SF: Reduce size of DisplayFrame according to "transparent region"

### DIFF
--- a/services/surfaceflinger/Layer.cpp
+++ b/services/surfaceflinger/Layer.cpp
@@ -374,7 +374,11 @@ void Layer::setGeometry(
     // apply the layer's transform, followed by the display's global transform
     // here we're guaranteed that the layer's transform preserves rects
     Rect frame(s.transform.transform(computeBounds()));
+    Rect transparentFrame(s.transform.transform(
+                s.activeTransparentRegion.getBounds()));
+    transparentFrame.intersect(hw->getViewport(), &transparentFrame);
     frame.intersect(hw->getViewport(), &frame);
+    frame = reduce(frame,Region(transparentFrame));
     const Transform& tr(hw->getTransform());
     layer.setFrame(tr.transform(frame));
 #ifdef QCOM_BSP


### PR DESCRIPTION
Calculating SourceCrop according to "transparent region" is taken care but
not DisplayFrame. DisplayFrame also need to be calculated according to
"transparent region" to avoid mismatch in SourceCrop and DisplayFrame.
This will avoid unwanted Scaling introduced because of mismatch.

CRs-Fixed: 651365
Change-Id: I33733c084702d46de1c9eb6663533fb083f9788a
