### PR TITLE
Themes: Fix -110 install error [1/2]

### DIFF
--- a/cmds/installd/installd.c
+++ b/cmds/installd/installd.c
@@ -135,6 +135,11 @@ static int do_idmap(char **arg, char reply[REPLY_MAX])
 
 static int do_aapt(char **arg, char reply[REPLY_MAX])
 {
+    return aapt(arg[0], arg[1], arg[2], atoi(arg[3]), atoi(arg[4]), "");
+}
+
+static int do_aapt_with_common(char **arg, char reply[REPLY_MAX])
+{
     return aapt(arg[0], arg[1], arg[2], atoi(arg[3]), atoi(arg[4]), arg[5]);
 }
 
@@ -163,7 +168,8 @@ struct cmdinfo cmds[] = {
     { "rmuser",               1, do_rm_user },
     { "restorecondata",       0, do_restorecon_data },
     { "idmap",                6, do_idmap },
-    { "aapt",                 6, do_aapt },
+    { "aapt",                 5, do_aapt },
+    { "aapt_with_common",     6, do_aapt_with_common },
 };
 
 char write_error = 0;


### PR DESCRIPTION
aapt was being called from PM with a ' ' at the end of the cmd. This would
cause installd to read unexpected parts of memory which sometimes
causes it to parse the command incorrectly.

Change-Id: Id9f1170db05b40f030d6ea5009bed38bc9fc3b5f
