### PR TITLE
Avoid calling idmap w/ trailing whitespace [2/2]

### DIFF
--- a/cmds/installd/installd.c
+++ b/cmds/installd/installd.c
@@ -130,6 +130,11 @@ static int do_restorecon_data(char **arg __attribute__((unused)),
 
 static int do_idmap(char **arg, char reply[REPLY_MAX])
 {
+    return idmap(arg[0], arg[1], atoi(arg[2]), atoi(arg[3]), atoi(arg[4]), "");
+}
+
+static int do_idmap_with_redirs(char **arg, char reply[REPLY_MAX])
+{
     return idmap(arg[0], arg[1], atoi(arg[2]), atoi(arg[3]), atoi(arg[4]), arg[5]);
 }
 
@@ -167,7 +172,8 @@ struct cmdinfo cmds[] = {
     { "mkuserdata",           4, do_mk_user_data },
     { "rmuser",               1, do_rm_user },
     { "restorecondata",       0, do_restorecon_data },
-    { "idmap",                6, do_idmap },
+    { "idmap",                5, do_idmap },
+    { "idmap_with_redirs",    6, do_idmap_with_redirs },
     { "aapt",                 5, do_aapt },
     { "aapt_with_common",     6, do_aapt_with_common },
 };


### PR DESCRIPTION
installd performs a buffer over-read if trailing ws is sent to it.
No observable effect found yet for idmap, but until installd is
fixed upstream, best to play it safe.

Change-Id: I002de7a9d177df16f91b47e7f87af59457c1f421
