### PR TITLE
surfaceflinger: Track the last surfaceview frame for latency dumps

### DIFF
--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -134,6 +134,8 @@ const String16 sAccessSurfaceFlinger("android.permission.ACCESS_SURFACE_FLINGER"
 const String16 sReadFramebuffer("android.permission.READ_FRAME_BUFFER");
 const String16 sDump("android.permission.DUMP");
 
+static sp<Layer> lastSurfaceViewLayer;
+
 // ---------------------------------------------------------------------------
 
 SurfaceFlinger::SurfaceFlinger()
@@ -1166,6 +1168,10 @@ void SurfaceFlinger::setUpHWComposer() {
                                             SurfaceFlinger::EVENT_ORIENTATION,
                                             uint32_t(draw[i].orientation));
                             }
+                        }
+                        if(!strncmp(layer->getName(), "SurfaceView",
+                                    11)) {
+                            lastSurfaceViewLayer = layer;
                         }
                     }
                 }
@@ -2677,13 +2683,18 @@ void SurfaceFlinger::dumpStatsLocked(const Vector<String16>& args, size_t& index
     if (name.isEmpty()) {
         mAnimFrameTracker.dump(result);
     } else {
+        bool found = false;
         const LayerVector& currentLayers = mCurrentState.layersSortedByZ;
         const size_t count = currentLayers.size();
         for (size_t i=0 ; i<count ; i++) {
             const sp<Layer>& layer(currentLayers[i]);
             if (name == layer->getName()) {
+                found = true;
                 layer->dumpStats(result);
             }
+        }
+        if (!found && !strncmp(name.string(), "SurfaceView", 11)) {
+            lastSurfaceViewLayer->dumpStats(result);
         }
     }
 }


### PR DESCRIPTION
When measuring GL latency with dumpsys, it's possible to hit a
race condition if the hardware is fast enough to complete rendering
the test cycle before the latency dump is requested, since it only
matches the latency for live layers (unless it's an animation. See
change I8bded1ea08a4cddefef0aa955401052bb9107c90)

So always save a reference to the last rendered SurfaceView frame,
and dump its values if there isn't an active one.

Change-Id: I740e9830161396ea955b5a53322bd8576b5136bc
