### PR TITLE
omx: Add nBitsPerSample parameter for FLAC

### DIFF
--- a/include/media/openmax/OMX_Audio.h
+++ b/include/media/openmax/OMX_Audio.h
@@ -378,6 +378,7 @@ typedef struct OMX_AUDIO_PARAM_FLACTYPE {
                                    unknown sampling rate. */
     OMX_U32 nCompressionLevel;/**< FLAC compression level, from 0 (fastest compression)
                                    to 8 (highest compression */
+    OMX_U32 nBitsPerSample;   /**< Number of bits in each sample */
 } OMX_AUDIO_PARAM_FLACTYPE;
 
 


### PR DESCRIPTION
- Necessary to convey this information from the extractor.

Change-Id: Ic6f689df9d5f840280bf0410021f6d6ee04a48d5
