### PR TITLE
sensorservice: Register orientation sensor if HAL doesn't provide it

### DIFF
--- a/services/sensorservice/SensorService.cpp
+++ b/services/sensorservice/SensorService.cpp
@@ -143,9 +143,14 @@ void SensorService::onFirstRef()
 
                 aSensor = registerVirtualSensor( new OrientationSensor() );
                 if (virtualSensorsNeeds & (1<<SENSOR_TYPE_ROTATION_VECTOR)) {
-                    // if we are doing our own rotation-vector, also add
-                    // the orientation sensor and remove the HAL provided one.
-                    mUserSensorList.replaceAt(aSensor, orientationIndex);
+                    if (orientationIndex == -1) {
+                        // some sensor HALs don't provide an orientation sensor.
+                        mUserSensorList.add(aSensor);
+                    } else {
+                        // if we are doing our own rotation-vector, also add
+                        // the orientation sensor and remove the HAL provided one.
+                        mUserSensorList.replaceAt(aSensor, orientationIndex);
+                    }
                 }
 
                 // virtual debugging sensors are not added to mUserSensorList


### PR DESCRIPTION
- In KitKat and on most Samsung devices, the orientation sensor is
  not getting registered, and makes the compass non-working in a lot
  of apps. This patch enables the sensor for such devices.

Change-Id: I0ebba72ec4aa2cfa02c21a6daff0c356c6793fd0
